### PR TITLE
Add support for loading from a .jshintrc file

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,17 @@ module.exports = function (destDir, options) {
 	options.complexity = options.complexity || {};
 	options.complexity.newmi = true;
 
+	if(typeof options.jshint === 'string') {
+		var fs = require('fs');
+
+		if (fs.existsSync(options.jshint)) {
+			// read in the .jshintrc file
+			var json = fs.readFileSync(options.jshint).toString();
+			var jshintOptions = JSON.parse(json);
+			options.jshint.options = jshintOptions;
+		}
+	}
+
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
 			this.push(file);

--- a/readme.md
+++ b/readme.md
@@ -40,20 +40,39 @@ gulp.task('default', function () {
 
 #### destDir
 
-*Required*  
+*Required*
 Type: `String`
 
 Report destination.
 
 #### options.jshint
 
-Type: `Object`  
+Type: `Object`
 
 [Options](http://www.jshint.com/docs/options/) passed to JSHint.
 
+Alternatively, you can set options.jshint to be the path to your existing .jshintrc file.
+
+Type: `string`
+
+```js
+var gulp = require('gulp');
+var plato = require('gulp-plato');
+
+gulp.task('default', function () {
+	return gulp.src('app.js')
+		.pipe(plato('report', {
+			jshint: '.jshintrc',
+			complexity: {
+				trycatch: true
+			}
+		}));
+});
+```
+
 #### options.complexity
 
-Type: `Object`  
+Type: `Object`
 
 [Options](https://github.com/philbooth/complexity-report#command-line-options) passed to complexity-report.
 


### PR DESCRIPTION
I generally have my jshint options in a .jshintrc file to make it easy to run from the commanline tool (http://www.jshint.com/docs/). This is a change to allow you to set the jshint options to a path rather than having to define the jshint options in the gulpfile as well as in my jshint file. For example:

``` js
var gulp = require('gulp');
var plato = require('gulp-plato');

gulp.task('default', function () {
    return gulp.src('app.js')
        .pipe(plato('report', {
            jshint: '.jshintrc',
            complexity: {
                trycatch: true
            }
        }));
});
```

This has helped me keep them in sync as I always have to just update the .jshintrc file
